### PR TITLE
add an opt-out config settings for this addon

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -88,8 +88,13 @@ export const renderLinkElement = (tagName) => {
   function LinkElement({ attributes, children, mode = 'edit', className }) {
     const Tag = tagName;
     const slug = attributes.id || '';
+    const { slate = {} } = config.settings;
 
-    return (
+    return slate.useLinkedHeadings === false ? (
+      <Tag className={className} {...attributes}>
+        {children}
+      </Tag>
+    ) : (
       <Tag className={className} {...attributes}>
         {mode === 'view' && slug && (
           <UniversalLink

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import ScrollToAnchor from './components/ScrollToAnchor';
 import { renderLinkElement } from './helpers';
 
 const applyConfig = (config) => {
+  config.settings.slate.useLinkedHeadings = true;
   config.settings.slate.elements = {
     ...config.settings.slate.elements,
     h1: renderLinkElement('h1'),
@@ -10,13 +11,15 @@ const applyConfig = (config) => {
     h4: renderLinkElement('h4'),
   };
 
-  config.settings.appExtras = [
-    ...(config.settings.appExtras || []),
-    {
-      match: '',
-      component: ScrollToAnchor,
-    },
-  ];
+  if (config.settings.slate.useLinkedHeadings) {
+    config.settings.appExtras = [
+      ...(config.settings.appExtras || []),
+      {
+        match: '',
+        component: ScrollToAnchor,
+      },
+    ];
+  }
   return config;
 };
 


### PR DESCRIPTION
It looks like it doesn't make sense to add this addon to a volto project and then opt-out from it, but we have this addon through [volto-eea-kitkat](https://github.com/eea/volto-eea-kitkat) and this way we can disable it easily, the same way that it can be disabled in volto master